### PR TITLE
Make JSONModel usage compatible with Swift 3

### DIFF
--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKAddToCart.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKAddToCart.m
@@ -1,4 +1,5 @@
 #import "VSDKAddToCart.h"
+#import "VSDKProduct.h"
 
 @implementation VSDKAddToCart
 
@@ -7,6 +8,12 @@
         self.type = @"addToCart";
     }
     return self;
+}
+
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"products"])
+        return [VSDKProduct class];
+    return nil;
 }
 
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKOrder.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKOrder.m
@@ -2,4 +2,10 @@
 
 @implementation VSDKOrder
 
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"promotions"])
+        return [NSString class];
+    return nil;
+}
+
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKOrderPlace.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKOrderPlace.m
@@ -1,3 +1,4 @@
+#import "VSDKLineItem.h"
 #import "VSDKOrderPlace.h"
 
 @implementation VSDKOrderPlace
@@ -7,6 +8,12 @@
         self.type = @"orderPlace";
     }
     return self;
+}
+
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"lineItems"])
+        return [VSDKLineItem class];
+    return nil;
 }
 
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProduct.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProduct.m
@@ -9,4 +9,10 @@
     return self;
 }
 
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"parts"])
+        return [VSDKProduct class];
+    return nil;
+}
+
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductClick.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductClick.m
@@ -1,3 +1,4 @@
+#import "VSDKProduct.h"
 #import "VSDKProductClick.h"
 
 @implementation VSDKProductClick
@@ -7,6 +8,12 @@
         self.type = @"productClick";
     }
     return self;
+}
+
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"products"])
+        return [VSDKProduct class];
+    return nil;
 }
 
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductCustomization.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductCustomization.m
@@ -1,3 +1,4 @@
+#import "VSDKProduct.h"
 #import "VSDKProductCustomization.h"
 
 @implementation VSDKProductCustomization
@@ -7,6 +8,12 @@
         self.type = @"productCustomization";
     }
     return self;
+}
+
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"products"])
+        return [VSDKProduct class];
+    return nil;
 }
 
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductFeedback.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductFeedback.m
@@ -1,3 +1,4 @@
+#import "VSDKProduct.h"
 #import "VSDKProductFeedback.h"
 
 @implementation VSDKProductFeedback
@@ -7,6 +8,12 @@
         self.type = @"productFeedback";
     }
     return self;
+}
+
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"products"])
+        return [VSDKProduct class];
+    return nil;
 }
 
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductImpression.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductImpression.m
@@ -1,3 +1,4 @@
+#import "VSDKProduct.h"
 #import "VSDKProductImpression.h"
 
 @implementation VSDKProductImpression
@@ -7,6 +8,12 @@
         self.type = @"productImpression";
     }
     return self;
+}
+
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"products"])
+        return [VSDKProduct class];
+    return nil;
 }
 
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductView.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductView.m
@@ -1,3 +1,4 @@
+#import "VSDKProduct.h"
 #import "VSDKProductView.h"
 
 @implementation VSDKProductView
@@ -7,6 +8,12 @@
         self.type = @"productView";
     }
     return self;
+}
+
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"products"])
+        return [VSDKProduct class];
+    return nil;
 }
 
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductViewDetails.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKProductViewDetails.m
@@ -1,3 +1,4 @@
+#import "VSDKProduct.h"
 #import "VSDKProductViewDetails.h"
 
 @implementation VSDKProductViewDetails
@@ -7,6 +8,12 @@
         self.type = @"productViewDetails";
     }
     return self;
+}
+
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"products"])
+        return [VSDKProduct class];
+    return nil;
 }
 
 @end

--- a/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKRemoveFromCart.m
+++ b/VelocidiSDK/VelocidiSDK/Tracking/Model/VSDKRemoveFromCart.m
@@ -1,3 +1,4 @@
+#import "VSDKProduct.h"
 #import "VSDKRemoveFromCart.h"
 
 @implementation VSDKRemoveFromCart
@@ -7,6 +8,12 @@
         self.type = @"removeFromCart";
     }
     return self;
+}
+
++ (Class)classForCollectionProperty:(NSString *)propertyName {
+    if ([propertyName isEqualToString:@"products"])
+        return [VSDKProduct class];
+    return nil;
 }
 
 @end


### PR DESCRIPTION
Makes JSONModel usage compatible with Swift 3 by implementing classForCollectionProperty on the class level for collections of nested models.