### PR TITLE
Add tests for the serialization of tracking events

### DIFF
--- a/VelocidiSDK/VelocidiSDK.xcodeproj/project.pbxproj
+++ b/VelocidiSDK/VelocidiSDK.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		1243B65F24C72E70007298CF /* VSDKAppView.h in Headers */ = {isa = PBXBuildFile; fileRef = 1243B65D24C72E6F007298CF /* VSDKAppView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1243B66024C72E70007298CF /* VSDKAppView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1243B65E24C72E6F007298CF /* VSDKAppView.m */; };
+		12FA833624E59C9A00C32D0F /* TrackingEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FA833524E59C9A00C32D0F /* TrackingEventsTests.swift */; };
 		303572D724CB588100280AC2 /* VSDKOrderPlace.h in Headers */ = {isa = PBXBuildFile; fileRef = 303572D524CB588100280AC2 /* VSDKOrderPlace.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		303572D824CB588100280AC2 /* VSDKOrderPlace.m in Sources */ = {isa = PBXBuildFile; fileRef = 303572D624CB588100280AC2 /* VSDKOrderPlace.m */; };
 		303572DB24CB5B2900280AC2 /* VSDKLineItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 303572D924CB5B2900280AC2 /* VSDKLineItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -121,6 +122,7 @@
 		0E2C4799C0C925EDCE50E8A1 /* Pods-VelocidiSDK-VelocidiSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VelocidiSDK-VelocidiSDKTests.debug.xcconfig"; path = "Target Support Files/Pods-VelocidiSDK-VelocidiSDKTests/Pods-VelocidiSDK-VelocidiSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		1243B65D24C72E6F007298CF /* VSDKAppView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VSDKAppView.h; sourceTree = "<group>"; };
 		1243B65E24C72E6F007298CF /* VSDKAppView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VSDKAppView.m; sourceTree = "<group>"; };
+		12FA833524E59C9A00C32D0F /* TrackingEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEventsTests.swift; sourceTree = "<group>"; };
 		303572D524CB588100280AC2 /* VSDKOrderPlace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VSDKOrderPlace.h; sourceTree = "<group>"; };
 		303572D624CB588100280AC2 /* VSDKOrderPlace.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VSDKOrderPlace.m; sourceTree = "<group>"; };
 		303572D924CB5B2900280AC2 /* VSDKLineItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VSDKLineItem.h; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 				30F3A0062264DE7000D9380B /* VelocidiTests.swift */,
 				30FA30712267731800BF442A /* RequestsTests.swift */,
 				30FA306F2267341A00BF442A /* UtilTests.swift */,
+				12FA833524E59C9A00C32D0F /* TrackingEventsTests.swift */,
 			);
 			path = VelocidiSDKTests;
 			sourceTree = "<group>";
@@ -619,6 +622,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				30F3A0072264DE7000D9380B /* VelocidiTests.swift in Sources */,
+				12FA833624E59C9A00C32D0F /* TrackingEventsTests.swift in Sources */,
 				30FA30722267731800BF442A /* RequestsTests.swift in Sources */,
 				30FA30702267341A00BF442A /* UtilTests.swift in Sources */,
 				30F3A00C2264E13300D9380B /* SanityTests.m in Sources */,

--- a/VelocidiSDK/VelocidiSDKTests/TrackingEventsTests.swift
+++ b/VelocidiSDK/VelocidiSDKTests/TrackingEventsTests.swift
@@ -1,0 +1,182 @@
+import UIKit
+import Quick
+import Nimble
+import Mockingjay
+import VelocidiSDK
+
+class TrackingEventsTests : QuickSpec {
+    override func spec() {
+        super.spec()
+        func serializesCorrectly(event: VSDKTrackingEvent) -> Bool? {
+            var success: Bool? = nil
+            do {
+                _ = try JSONModel.init(data: event.toJSONData())
+                success = true
+            } catch {
+                success = false
+            }
+            return success
+        }
+        
+        let product = VSDKProduct()
+        product.productId = "1"
+        product.name = "1"
+        product.brand = "brand1"
+        product.category = "cat1"
+        product.price = 1.0
+        
+        describe("VSDKAddToCart"){
+            let event = VSDKAddToCart()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.products = NSMutableArray(array: [product])
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKAppView"){
+            let event = VSDKAppView()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.title = "a"
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKOrderPlace"){
+            let event = VSDKOrderPlace()
+            event.siteId = "0"
+            event.clientId = "0"
+            let lineItem = VSDKLineItem()
+            lineItem.id = "1"
+            lineItem.currency = "EUR"
+            lineItem.total = 1.0
+            lineItem.subtotal = 1.0
+            lineItem.tax = 1.0
+            lineItem.shipping = 1.0
+            let order = VSDKOrder()
+            order.id = "1"
+            order.currency = "EUR"
+            order.total = 1.0
+            order.subtotal = 1.0
+            order.tax = 1.0
+            order.shipping = 1.0
+            event.order = order
+            event.lineItems = NSMutableArray(array: [lineItem])
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKPageView"){
+            let event = VSDKPageView()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.location = "a"
+            event.title = "b"
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKProductClick"){
+            let event = VSDKProductClick()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.products = NSMutableArray(array: [product])
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKProductCustomization"){
+            let event = VSDKProductCustomization()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.products = NSMutableArray(array: [product])
+            let cust = VSDKCustomization()
+            cust.name = "a"
+            cust.price = 1.0
+            event.productCustomization = cust
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKProductFeedback"){
+            let event = VSDKProductFeedback()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.products = NSMutableArray(array: [product])
+            event.rating = 2.5
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKProductImpression"){
+            let event = VSDKProductImpression()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.products = NSMutableArray(array: [product])
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKProductView"){
+            let event = VSDKProductView()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.products = NSMutableArray(array: [product])
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKProductViewDetails"){
+            let event = VSDKProductViewDetails()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.products = NSMutableArray(array: [product])
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKRemoveFromCart"){
+            let event = VSDKRemoveFromCart()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.products = NSMutableArray(array: [product])
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+        
+        describe("VSDKSearch"){
+            let event = VSDKSearch()
+            event.siteId = "0"
+            event.clientId = "0"
+            event.query = "a"
+            
+            it("should serialize correctly") {
+                expect(serializesCorrectly(event: event)).to(beTrue())
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
Following the bug that #29 fixes, it looked a good idea to have some tests that check that all events are serializing correctly.

Depends on #29.