### PR TITLE
Change build setting to avoid swift compilation problems on xcode 12

### DIFF
--- a/VelocidiSDK/VelocidiSDK.xcodeproj/project.pbxproj
+++ b/VelocidiSDK/VelocidiSDK.xcodeproj/project.pbxproj
@@ -813,7 +813,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = VelocidiSDKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.velocidi.VelocidiSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
@@ -858,7 +858,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = VelocidiSDKTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.velocidi.VelocidiSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";


### PR DESCRIPTION
On Xcode 12 trying to build and test the `VelocidiSDK` project resulted in `swift` compilation failures. This seems to correct that. 