### PR TITLE
Docs standardize

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -10,15 +10,3 @@ module: VelocidiSDK
 output: ./docs/docs_page/
 theme: docs/velocidi-jazzy-theme/
 readme: ./docs/tmp/readme/README.md
-documentation: 
-  - ./docs/*.md 
-  - ./docs/tmp/docs/*.md 
-custom_categories: 
-  - name: Guides 
-    children: 
-      - Installation
-      - Setting up the SDK
-      - Send a track event
-      - Make a match
-      - Custom tracking events
-      - Tracking model classes list

--- a/.scripts/build_docs.sh
+++ b/.scripts/build_docs.sh
@@ -11,8 +11,8 @@ if ! [ -x "$(command -v jazzy)" ]; then
   exit 1
 fi
 
-if ! jazzy -v | grep -q '0.10.0'; then
-  echo "\033[0;33mWarning\033[0m: Not using recommended jazzy version. Recommended jazzy version is 0.10.0."
+if ! jazzy -v | grep -q '0.13.6'; then
+  echo "\033[0;33mWarning\033[0m: Not using recommended jazzy version. Recommended jazzy version is 0.13.6."
 fi
 
 jazzy

--- a/docs/velocidi-jazzy-theme/assets/css/custom.css.scss
+++ b/docs/velocidi-jazzy-theme/assets/css/custom.css.scss
@@ -55,3 +55,8 @@ header {
 #breadcrumbs {
   background-color: $custom_bg_color;
 }
+
+.external-link svg {
+  position: relative;
+  bottom: -0.1rem;
+}

--- a/docs/velocidi-jazzy-theme/templates/header.mustache
+++ b/docs/velocidi-jazzy-theme/templates/header.mustache
@@ -4,6 +4,18 @@
     {{#github_url}}
     <p class="header-right"><a href="{{github_url}}"><img src="{{path_to_root}}img/gh.png"/>View on GitHub</a></p>
     {{/github_url}}
+    <p class="header-right external-link"><a href="https://velocidi.com">
+      Velocidi
+      <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" x="0px" y="0px" viewBox="0 0 100 100" width="15" height="15" class="icon outbound"><path fill="currentColor" d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z"></path> <polygon fill="currentColor" points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9"></polygon></svg>
+    </a></p>
+    <p class="header-right external-link"><a href="https://docs.velocidi.com">
+      Product Documentation
+      <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" x="0px" y="0px" viewBox="0 0 100 100" width="15" height="15" class="icon outbound"><path fill="currentColor" d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z"></path> <polygon fill="currentColor" points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9"></polygon></svg>
+    </a></p>
+    <p class="header-right external-link"><a href="https://developers.velocidi.com">
+      Developers Documentation
+      <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" x="0px" y="0px" viewBox="0 0 100 100" width="15" height="15" class="icon outbound"><path fill="currentColor" d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z"></path> <polygon fill="currentColor" points="45.7,48.7 51.3,54.3 77.2,28.5 77.2,37.2 85.2,37.2 85.2,14.9 62.8,14.9 62.8,22.9 71.5,22.9"></polygon></svg>
+    </a></p>
     {{#dash_url}}
     <p class="header-right"><a href="{{dash_url}}"><img src="{{path_to_root}}img/dash.png"/>Install in Dash</a></p>
     {{/dash_url}}


### PR DESCRIPTION
This PR:
* Removes the Guides section in the docs website
* Adds the relevant external links (similar to https://android.developers.velocidi.com)

![image](https://user-images.githubusercontent.com/7612420/98564650-8538b880-22a4-11eb-9a2b-6c269ce41cbb.png)

* Updates jazzy from 0.10.0 to 0.13.6
