### PR TITLE
Add SwiftLint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           TEST_SDK: "${{ matrix.sdk }}"
           TEST_DEVICE: "${{ matrix.device }}"
         run: ./.github/workflows/xcodebuild.sh clean build test
+      - name: "Verify code linting generated no changes"
+        run: git diff --exit-code
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
@@ -70,6 +72,8 @@ jobs:
         env:
           SCHEME: "SwiftExample"
         run: ./.github/workflows/xcodebuild.sh clean build
+      - name: "Verify code linting generated no changes"
+        run: git diff --exit-code
 
   pods-lint:
     name: "Cocoapods Lint"

--- a/.scripts/swiftlint.sh
+++ b/.scripts/swiftlint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+
+if ! command -v Pods/SwiftLint/swiftlint &> /dev/null
+then
+    echo "Swiftlint does not seem to be installed. You may need to run 'pod install'."
+    exit
+fi
+
+
+if [ -z "$1" ]
+then
+    Pods/SwiftLint/swiftlint lint --fix && Pods/SwiftLint/swiftlint lint --strict
+else
+    Pods/SwiftLint/swiftlint lint "$1" --fix && Pods/SwiftLint/swiftlint lint "$1" --strict
+fi

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,2 @@
+excluded:
+  Pods

--- a/Examples/Podfile
+++ b/Examples/Podfile
@@ -8,6 +8,7 @@ target "SwiftExample" do
   project 'SwiftExample/SwiftExample.xcodeproj'
 
   pod 'VelocidiSDK', :path => '../'
+  pod 'SwiftLint'
 end
 
 target "ObjcExample" do

--- a/Examples/Podfile.lock
+++ b/Examples/Podfile.lock
@@ -15,17 +15,20 @@ PODS:
   - AFNetworking/UIKit (3.2.1):
     - AFNetworking/NSURLSession
   - JSONModel (1.8.0)
+  - SwiftLint (0.43.0)
   - VelocidiSDK (0.3.2):
     - AFNetworking (~> 3.2.1)
     - JSONModel (~> 1.8)
 
 DEPENDENCIES:
+  - SwiftLint
   - VelocidiSDK (from `../`)
 
 SPEC REPOS:
   trunk:
     - AFNetworking
     - JSONModel
+    - SwiftLint
 
 EXTERNAL SOURCES:
   VelocidiSDK:
@@ -34,8 +37,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
   JSONModel: 02ab723958366a3fd27da57ea2af2113658762e9
+  SwiftLint: 0c645fdc6feed3e390c1701ab3cc669f88b42752
   VelocidiSDK: 5d72bfe2753893b6c7a62da11c3ace4b0ec23634
 
-PODFILE CHECKSUM: e2e23bb295a730aba4d1ace8e2b2dcd242f04f30
+PODFILE CHECKSUM: 68dce33b43039039eeef0dfe46e50e0bba56f7c5
 
 COCOAPODS: 1.10.1

--- a/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 				30B0DE2C226E022F00A0919B /* Frameworks */,
 				30B0DE2D226E022F00A0919B /* Resources */,
 				9D5B93C6D2E989AE2C83E635 /* [CP] Embed Pods Frameworks */,
+				A16A45AE25FD866900B6A451 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -205,6 +206,23 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftExample/Pods-SwiftExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		A16A45AE25FD866900B6A451 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" autocorrect && \"${PODS_ROOT}/SwiftLint/swiftlint\" --strict\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Examples/SwiftExample/SwiftExample/AppDelegate.swift
+++ b/Examples/SwiftExample/SwiftExample/AppDelegate.swift
@@ -7,42 +7,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         if #available(iOS 14, *) {
-            ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in })
+            ATTrackingManager.requestTrackingAuthorization(completionHandler: { _ in })
         }
-        
+
         let config = VSDKConfig(trackingBaseUrl: "http://localhost:8080", "http://localhost:8080")!
         VSDKVelocidi.start(config)
-        
+
         return true
     }
-
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
-
 }
-

--- a/Examples/SwiftExample/SwiftExample/ViewController.swift
+++ b/Examples/SwiftExample/SwiftExample/ViewController.swift
@@ -8,41 +8,43 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
     }
-    
+
     var trackingNumber = 0
     var matchNumber = 0
 
-    //MARK: Actions
+    // MARK: Actions
     @IBAction func sendTrackingEvent(_ sender: UIButton) {
         let trackingEvent = VSDKPageView()
         trackingEvent.siteId = "foo"
         trackingEvent.clientId = "bar"
-        
+
         trackingNumber += 1
         let currentTrNumber = trackingNumber
-        
-        VSDKVelocidi.sharedInstance().track(trackingEvent, onSuccess:{ (response: URLResponse, responseObject: Any) in
+
+        VSDKVelocidi.sharedInstance().track(trackingEvent, onSuccess: { (_: URLResponse, _: Any) in
             self.mainLabel.text = "Tracking request #\(currentTrNumber) successful!"
-        }, onFailure:{(error: Error) in
-            self.mainLabel.text = "Error with tracking request #\(currentTrNumber).\n Error: \(error.localizedDescription)"
+        }, onFailure: {(error: Error) in
+            self.mainLabel.text =
+                "Error with tracking request #\(currentTrNumber).\n Error: \(error.localizedDescription)"
         })
     }
-    
+
     var customTrackingNumber = 0
-    
+
     @IBAction func sendCustomTrackingEvent(_ sender: Any) {
         let trackingEvent = CustomEvent()
         trackingEvent.siteId = "foo"
         trackingEvent.clientId = "bar"
         trackingEvent.customField = "baz"
-        
+
         customTrackingNumber += 1
         let currentCustomTrNumber = customTrackingNumber
-        
-        VSDKVelocidi.sharedInstance().track(trackingEvent, onSuccess:{ (response: URLResponse, responseObject: Any) in
+
+        VSDKVelocidi.sharedInstance().track(trackingEvent, onSuccess: { (_: URLResponse, _: Any) in
             self.mainLabel.text = "Custom Tracking request #\(currentCustomTrNumber) successful!"
-        }, onFailure:{(error: Error) in
-            self.mainLabel.text = "Error with custom tracking request #\(currentCustomTrNumber).\n Error: \(error.localizedDescription)"
+        }, onFailure: {(error: Error) in
+            self.mainLabel.text =
+                "Error with custom tracking request #\(currentCustomTrNumber).\n Error: \(error.localizedDescription)"
         })
     }
 
@@ -53,12 +55,14 @@ class ViewController: UIViewController {
 
         matchNumber += 1
         let currentMatchNumber = matchNumber
-        
-        VSDKVelocidi.sharedInstance().match("1234-providerId-56789", userIds: idsArray, onSuccess:{ (response: URLResponse, responseObject: Any) in
+
+        VSDKVelocidi
+            .sharedInstance()
+            .match("1234-providerId-56789", userIds: idsArray, onSuccess: { (_: URLResponse, _: Any) in
             self.mainLabel.text = "Match request #\(currentMatchNumber) successful!"
-        }, onFailure:{(error: Error) in
-            self.mainLabel.text = "Error with match request #\(currentMatchNumber).\n Error: \(error.localizedDescription)"
+        }, onFailure: {(error: Error) in
+            self.mainLabel.text =
+                "Error with match request #\(currentMatchNumber).\n Error: \(error.localizedDescription)"
         })
     }
 }
-

--- a/Podfile
+++ b/Podfile
@@ -12,6 +12,7 @@ target "VelocidiSDK" do
   target "VelocidiSDKTests" do
     inherit! :complete
 
+    pod 'SwiftLint'
     pod 'Quick', '~> 2.0', :inhibit_warnings => true # Quick 3 raises the xcode version requirement to v11
     pod 'Nimble', '~> 8.0' # Nimble 9 raises the xcode version requirement to v11
     pod 'Mockingjay'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,6 +24,7 @@ PODS:
     - Mockingjay/Core
   - Nimble (8.1.2)
   - Quick (2.2.1)
+  - SwiftLint (0.43.0)
   - URITemplate (2.0.3)
 
 DEPENDENCIES:
@@ -32,6 +33,7 @@ DEPENDENCIES:
   - Mockingjay
   - Nimble (~> 8.0)
   - Quick (~> 2.0)
+  - SwiftLint
 
 SPEC REPOS:
   trunk:
@@ -40,6 +42,7 @@ SPEC REPOS:
     - Mockingjay
     - Nimble
     - Quick
+    - SwiftLint
     - URITemplate
 
 SPEC CHECKSUMS:
@@ -48,8 +51,9 @@ SPEC CHECKSUMS:
   Mockingjay: 11a621880d2887f1775bdcf824341eb68f218450
   Nimble: 3864815b4703c7ebffba875973c70e854489fbae
   Quick: f5754d69b7013f5864c29aab9ae6f0c79c5bc200
+  SwiftLint: 0c645fdc6feed3e390c1701ab3cc669f88b42752
   URITemplate: ace0c4c46dcf8afe6e89b4060621852886b15c3b
 
-PODFILE CHECKSUM: 1d10df8de075df900157ec6be361de678c2cfd86
+PODFILE CHECKSUM: e35cb5100678904f3ad825a90f3ce0e6c11307a5
 
 COCOAPODS: 1.10.1

--- a/VelocidiSDK.xcworkspace/contents.xcworkspacedata
+++ b/VelocidiSDK.xcworkspace/contents.xcworkspacedata
@@ -3,6 +3,22 @@
    version = "1.0">
    <Group
       location = "container:"
+      name = "Scripts">
+      <FileRef
+         location = "group:.scripts/build_docs.sh">
+      </FileRef>
+      <FileRef
+         location = "group:.scripts/deploy.sh">
+      </FileRef>
+      <FileRef
+         location = "group:.scripts/split_readme.sh">
+      </FileRef>
+      <FileRef
+         location = "group:.scripts/swiftlint.sh">
+      </FileRef>
+   </Group>
+   <Group
+      location = "container:"
       name = "CI">
       <FileRef
          location = "group:.github/workflows/xcodebuild.sh">

--- a/VelocidiSDK/VelocidiSDK.xcodeproj/project.pbxproj
+++ b/VelocidiSDK/VelocidiSDK.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 				B1432D1A6E4A3AC683544056 /* Frameworks */,
 				B1432D2375A47DCBB54B7EE6 /* Resources */,
 				78D6C2DDFFEDAF50A771284C /* [CP] Embed Pods Frameworks */,
+				A16A45AD25FD577800B6A451 /* ShellScript */,
 			);
 			buildRules = (
 				3060595D2264DA2E00306E32 /* PBXBuildRule */,
@@ -553,6 +554,23 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-VelocidiSDK-VelocidiSDKTests/Pods-VelocidiSDK-VelocidiSDKTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		A16A45AD25FD577800B6A451 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" autocorrect && \"${PODS_ROOT}/SwiftLint/swiftlint\" --strict\n";
 		};
 		B61CE0967F3E6E8420CE0F5E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/VelocidiSDK/VelocidiSDKTests/RequestsTests.swift
+++ b/VelocidiSDK/VelocidiSDKTests/RequestsTests.swift
@@ -5,13 +5,14 @@ import VelocidiSDK
 import AdSupport
 import Foundation
 
+// swiftlint:disable function_body_length
 class RequestsTests: QuickSpec {
     override func spec() {
         super.spec()
         describe("VSDKRequests") {
             it("should not make a tracking request if tracking is not allowed") {
-                
-                class MockRequest: VSDKTrackingRequest{
+
+                class MockRequest: VSDKTrackingRequest {
                     override func tryGetIDFA() throws -> String {
                         throw NSError(domain: "com.velocidi.VSDKTrackingNotAllowedError", code: 1, userInfo: nil)
                     }
@@ -22,7 +23,7 @@ class RequestsTests: QuickSpec {
                 trackingEvent.siteId = "0"
                 trackingEvent.clientId = "0"
 
-                var requestExecuted: Bool? = nil
+                var requestExecuted: Bool?
 
                 self.stub({(request: URLRequest) in
                     return request.url!.absoluteString.starts(with: url)
@@ -32,10 +33,10 @@ class RequestsTests: QuickSpec {
                 request.url = URL(string: url)!
                 request.data = trackingEvent
 
-                request.perform({_,_ in
+                request.perform({_, _ in
                     requestExecuted = true
                 }, {(error: Error) in
-                    if ((error as NSError).domain == "com.velocidi.VSDKTrackingNotAllowedError") {
+                    if (error as NSError).domain == "com.velocidi.VSDKTrackingNotAllowedError" {
                         requestExecuted = false
                     } else {
                         requestExecuted = true
@@ -45,10 +46,10 @@ class RequestsTests: QuickSpec {
                 expect(requestExecuted).toEventuallyNot(beNil())
                 expect(requestExecuted).to(beFalse())
             }
-            
+
             it("should use the provided User-Agent") {
-               
-                class MockRequest: VSDKTrackingRequest{
+
+                class MockRequest: VSDKTrackingRequest {
                     override func tryGetIDFA() throws -> String {
                         return "00000000-0000-0000-0000-000000000000"
                     }
@@ -56,34 +57,35 @@ class RequestsTests: QuickSpec {
                         return "fooUserAgent"
                     }
                 }
-                
+
                 let url = "http://testdomain.com"
                 let trackingEvent = VSDKPageView()
                 trackingEvent.siteId = "0"
                 trackingEvent.clientId = "0"
-                
+
                 var requestExecuted: Bool = false
-                
+
                 self.stub({(request: URLRequest) in
                     return request.url!.absoluteString.starts(with: url)
                 }, { (request: URLRequest) in
-                    if(request.allHTTPHeaderFields?["User-Agent"] == "fooUserAgent") {
-                        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                    if request.allHTTPHeaderFields?["User-Agent"] == "fooUserAgent" {
+                        let response = HTTPURLResponse(
+                            url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
                         return .success(response, .noContent)
                     }
                     return .failure(NSError(domain: url, code: 400))
                 })
-                
+
                 let request = MockRequest()
                 request.url = URL(string: url)!
                 request.data = trackingEvent
-                
-                request.perform({_,_ in
+
+                request.perform({_, _ in
                     requestExecuted = true
-                }, {(error: Error) in
+                }, {(_: Error) in
                     requestExecuted = false
                 })
-                
+
                 expect(requestExecuted).toEventually(beTrue())
             }
         }

--- a/VelocidiSDK/VelocidiSDKTests/TrackingEventsTests.swift
+++ b/VelocidiSDK/VelocidiSDKTests/TrackingEventsTests.swift
@@ -4,11 +4,12 @@ import Nimble
 import Mockingjay
 import VelocidiSDK
 
-class TrackingEventsTests : QuickSpec {
+class TrackingEventsTests: QuickSpec {
+    // swiftlint:disable function_body_length
     override func spec() {
         super.spec()
         func serializesCorrectly(event: VSDKTrackingEvent) -> Bool? {
-            var success: Bool? = nil
+            var success: Bool?
             do {
                 _ = try JSONModel.init(data: event.toJSONData())
                 success = true
@@ -17,37 +18,37 @@ class TrackingEventsTests : QuickSpec {
             }
             return success
         }
-        
+
         let product = VSDKProduct()
         product.productId = "1"
         product.name = "1"
         product.brand = "brand1"
         product.category = "cat1"
         product.price = 1.0
-        
-        describe("VSDKAddToCart"){
+
+        describe("VSDKAddToCart") {
             let event = VSDKAddToCart()
             event.siteId = "0"
             event.clientId = "0"
             event.products = NSMutableArray(array: [product])
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKAppView"){
+
+        describe("VSDKAppView") {
             let event = VSDKAppView()
             event.siteId = "0"
             event.clientId = "0"
             event.title = "a"
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKOrderPlace"){
+
+        describe("VSDKOrderPlace") {
             let event = VSDKOrderPlace()
             event.siteId = "0"
             event.clientId = "0"
@@ -67,36 +68,36 @@ class TrackingEventsTests : QuickSpec {
             order.shipping = 1.0
             event.order = order
             event.lineItems = NSMutableArray(array: [lineItem])
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKPageView"){
+
+        describe("VSDKPageView") {
             let event = VSDKPageView()
             event.siteId = "0"
             event.clientId = "0"
             event.location = "a"
             event.title = "b"
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKProductClick"){
+
+        describe("VSDKProductClick") {
             let event = VSDKProductClick()
             event.siteId = "0"
             event.clientId = "0"
             event.products = NSMutableArray(array: [product])
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKProductCustomization"){
+
+        describe("VSDKProductCustomization") {
             let event = VSDKProductCustomization()
             event.siteId = "0"
             event.clientId = "0"
@@ -105,78 +106,78 @@ class TrackingEventsTests : QuickSpec {
             cust.name = "a"
             cust.price = 1.0
             event.productCustomization = cust
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKProductFeedback"){
+
+        describe("VSDKProductFeedback") {
             let event = VSDKProductFeedback()
             event.siteId = "0"
             event.clientId = "0"
             event.products = NSMutableArray(array: [product])
             event.rating = 2.5
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKProductImpression"){
+
+        describe("VSDKProductImpression") {
             let event = VSDKProductImpression()
             event.siteId = "0"
             event.clientId = "0"
             event.products = NSMutableArray(array: [product])
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKProductView"){
+
+        describe("VSDKProductView") {
             let event = VSDKProductView()
             event.siteId = "0"
             event.clientId = "0"
             event.products = NSMutableArray(array: [product])
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKProductViewDetails"){
+
+        describe("VSDKProductViewDetails") {
             let event = VSDKProductViewDetails()
             event.siteId = "0"
             event.clientId = "0"
             event.products = NSMutableArray(array: [product])
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKRemoveFromCart"){
+
+        describe("VSDKRemoveFromCart") {
             let event = VSDKRemoveFromCart()
             event.siteId = "0"
             event.clientId = "0"
             event.products = NSMutableArray(array: [product])
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
-        
-        describe("VSDKSearch"){
+
+        describe("VSDKSearch") {
             let event = VSDKSearch()
             event.siteId = "0"
             event.clientId = "0"
             event.query = "a"
-            
+
             it("should serialize correctly") {
                 expect(serializesCorrectly(event: event)).to(beTrue())
             }
         }
     }
-    
+
 }

--- a/VelocidiSDK/VelocidiSDKTests/UtilTests.swift
+++ b/VelocidiSDK/VelocidiSDKTests/UtilTests.swift
@@ -10,8 +10,10 @@ class UtilTests: QuickSpec {
         describe("VSDKUtil") {
             it("should generate a valid User-Agent containing information about VelocidiSDK") {
                 let userAgent = VSDKUtil.getVersionedUserAgent()
-                let regexStr = String(format:".*/.* VelocidiSDK\\/%@ \\(%@; %@ %@; Scale\\/%0.2f\\)",
-                    Bundle(identifier: "com.velocidi.VelocidiSDK")?.infoDictionary!["CFBundleShortVersionString"] as! String,
+                let regexStr = String(format: ".*/.* VelocidiSDK\\/%@ \\(%@; %@ %@; Scale\\/%0.2f\\)",
+                    // swiftlint:disable force_cast
+                    Bundle(identifier: "com.velocidi.VelocidiSDK")?
+                        .infoDictionary!["CFBundleShortVersionString"] as! String,
                     UIDevice.current.model,
                     UIDevice.current.systemName,
                     UIDevice.current.systemVersion,
@@ -19,7 +21,7 @@ class UtilTests: QuickSpec {
 
                 expect(userAgent).to(match(regexStr))
             }
-            
+
             if #available(iOS 14, *) { // ios14 is opt-in
                 it("should throw an error when trying to get the IDFA on iOS 14+") {
                     // this style is necessary because of https://github.com/Quick/Nimble/issues/809
@@ -29,10 +31,11 @@ class UtilTests: QuickSpec {
                 }
             } else { // previous ios version are opt-out
                 it("should successfuly provide the IDFA") {
-                    expect(try? VSDKUtil.tryGetIDFA()).to(match("[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}"))
+                    expect(try? VSDKUtil.tryGetIDFA())
+                        .to(match("[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}"))
                 }
             }
-            
+
         }
     }
 }

--- a/VelocidiSDK/VelocidiSDKTests/VelocidiTests.swift
+++ b/VelocidiSDK/VelocidiSDKTests/VelocidiTests.swift
@@ -27,32 +27,34 @@ extension Data {
     }
 }
 
+// swiftlint:disable function_body_length
 class NetworkTests: QuickSpec {
     override func spec() {
         super.spec()
         describe("VelocidiSDK") {
             let trackURL = "http://tr.testdomain.com"
             let matchURL = "http://match.testdomain.com"
-            
-            context("test track request"){
+
+            context("test track request") {
 
                 func responseBuilder(url: String, expectedData: Data) -> (URLRequest) -> (Response) {
                     return { (request: URLRequest) in
-                        if(request.url!.absoluteString.starts(with: url)
+                        if request.url!.absoluteString.starts(with: url)
                             && request.allHTTPHeaderFields?["Content-Type"] == "application/json"
                             && request.allHTTPHeaderFields?["User-Agent"] != nil
-                            && request.httpBodyStream != nil) {
+                            && request.httpBodyStream != nil {
 
                             let receivedData = Data(reading: request.httpBodyStream!)
-                            if(receivedData == expectedData){
-                                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                            if receivedData == expectedData {
+                                let response = HTTPURLResponse(
+                                    url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
                                 return .success(response, .noContent)
                             }
                         }
                         return .failure(NSError(domain: trackURL, code: 400))
                     }
                 }
-                
+
                 func test(success: UnsafeMutablePointer<Bool?>, error: UnsafeMutablePointer<Error?>) {
                     let trackingEvent = VSDKPageView()
                     trackingEvent.siteId = "0"
@@ -60,73 +62,72 @@ class NetworkTests: QuickSpec {
 
                     self.stub({(request: URLRequest) in
                         return request.url!.absoluteString.starts(with: trackURL)
-                    }, responseBuilder(url:trackURL, expectedData:trackingEvent.toJSONData()))
-
+                    }, responseBuilder(url: trackURL, expectedData: trackingEvent.toJSONData()))
 
                     let config = VSDKConfig(trackingBaseUrl: trackURL, matchURL)
                     VSDKVelocidi.start(config!)
 
-                    VSDKVelocidi.sharedInstance().track(trackingEvent, onSuccess:{ (response: URLResponse, responseObject: Any) in
+                    VSDKVelocidi.sharedInstance().track(trackingEvent, onSuccess: { (_: URLResponse, _: Any) in
                         success.pointee = true
-                    }, onFailure:{(err: Error) in
+                    }, onFailure: {(err: Error) in
                         success.pointee = false
                         error.pointee = err
                     })
                 }
-                
+
                 // iOS 14 is opt-in and so these requests fail.
                 // We cannot configure the environment to act in a different way.
                 if #available(iOS 14, *) {
                     it("should fail to execute tracking requests when the user is not opted-in in iOS 14") {
-                        var success: Bool? = nil
-                        var error: Error? = nil
+                        var success: Bool?
+                        var error: Error?
                         test(success: &success, error: &error)
-                        
+
                         expect(success).toEventually(beFalse(), timeout: 4)
                         expect(error).toEventually(beAnInstanceOf(NSError.self), timeout: 4)
                         expect(error!._domain).to(equal("com.velocidi.VSDKTrackingNotAllowedError"))
                     }
                 } else {
                     it("should successfuly execute tracking requests") {
-                        var success: Bool? = nil
-                        var error: Error? = nil
+                        var success: Bool?
+                        var error: Error?
                         test(success: &success, error: &error)
-                        
+
                         expect(success).toEventually(beTrue(), timeout: 4)
                         expect(error).to(beNil())
                     }
                 }
             }
 
-            context("test match requests"){
-                func  responseBuilder(url: String, expectedParams: Dictionary<String, String>) -> (URLRequest) -> (Response) {
+            context("test match requests") {
+                func  responseBuilder(url: String, expectedParams: [String: String]) -> (URLRequest) -> (Response) {
                     return { (request: URLRequest) in
                         let requestUrl = request.url!.absoluteString
                         var hasAllParams = true
                         expectedParams.forEach { (key, value) in
-                            if(!requestUrl.contains("\(key)=\(value)")){
+                            if !requestUrl.contains("\(key)=\(value)") {
                                 hasAllParams = false
                             }
                         }
 
-                        if(requestUrl.starts(with: url)
+                        if requestUrl.starts(with: url)
                             && request.allHTTPHeaderFields?["User-Agent"] != nil
-                            && hasAllParams
-                            ){
-                            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                            && hasAllParams {
+                            let response = HTTPURLResponse(
+                                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
                             return .success(response, .noContent)
                         }
                         return .failure(NSError(domain: trackURL, code: 400))
                     }
                 }
-                
+
                 func test(success: UnsafeMutablePointer<Bool?>, error: UnsafeMutablePointer<Error?>) {
                     let userId1 = VSDKUserId(userId: "bar", "foo")
                     let userId2 = VSDKUserId(userId: "y", "x")
 
-                    let arrUserIds = NSMutableArray(array: [userId1,userId2])
-                    
-                    var expectedParams = Dictionary<String, String>()
+                    let arrUserIds = NSMutableArray(array: [userId1, userId2])
+
+                    var expectedParams = [String: String]()
                     expectedParams["cookies"] = "false"
                     for case let userId as VSDKUserId in arrUserIds {
                         expectedParams["id_\(userId.type)"] = userId.userId
@@ -134,39 +135,38 @@ class NetworkTests: QuickSpec {
 
                     self.stub({(request: URLRequest) in
                         return request.url!.absoluteString.starts(with: matchURL)
-                    }, responseBuilder(url:matchURL, expectedParams: expectedParams))
-                    
+                    }, responseBuilder(url: matchURL, expectedParams: expectedParams))
+
                     let config = VSDKConfig(trackingBaseUrl: trackURL, matchURL)
                     VSDKVelocidi.start(config!)
-                    
-                    VSDKVelocidi.sharedInstance().match("baz", userIds: arrUserIds, onSuccess:{ (response: URLResponse, responseObject: Any) in
+
+                    VSDKVelocidi.sharedInstance()
+                        .match("baz", userIds: arrUserIds, onSuccess: { (_: URLResponse, _: Any) in
                         success.pointee = true
-                    }, onFailure:{(err: Error) in
+                    }, onFailure: {(err: Error) in
                         success.pointee = false
                         error.pointee = err
                     })
                 }
-                
-                
+
                 // iOS 14 is opt-in and so these requests fail.
                 // We cannot configure the environment to act in a different way.
                 if #available(iOS 14, *) {
                     it("should fail to execute match requests when the user is not opted-in in iOS 14") {
-                        var success: Bool? = nil
-                        var error: Error? = nil
+                        var success: Bool?
+                        var error: Error?
                         test(success: &success, error: &error)
-                        
-                        
+
                         expect(success).toEventually(beFalse(), timeout: 4)
                         expect(error).toEventually(beAnInstanceOf(NSError.self), timeout: 4)
                         expect(error!._domain).to(equal("com.velocidi.VSDKTrackingNotAllowedError"))
                     }
                 } else {
                     it("should successfuly execute match requests") {
-                        var success: Bool? = nil
-                        var error: Error? = nil
+                        var success: Bool?
+                        var error: Error?
                         test(success: &success, error: &error)
-                        
+
                         expect(success).toEventually(beTrue(), timeout: 4)
                         expect(error).to(beNil())
                     }


### PR DESCRIPTION
This runs [SwiftLint](https://github.com/realm/SwiftLint) as a new "Run Script" phase during compilation of VelocidiSDK tests and SwiftExample. In CI, It also verifies that no diff exists after compilation.

I did not went through the trouble of refactoring the tests to get rid of the method length warning, because we only use Swift for tests. I just ignored it.

The script that runs during the build is the following:
```
"${PODS_ROOT}/SwiftLint/swiftlint" autocorrect && "${PODS_ROOT}/SwiftLint/swiftlint" --strict
```
I am autocorrecting things here. 
I guess we can not do that and I am open to change that behavior. I did it this way, I guess, because the workflow to apply the required changes may be a bit cumbersome given that we may be forced to call the tool by ourselves through the command line... 🤷 . Thoughts?

This depends on #45.