### PR TITLE
Ignore coverage from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          xcode_package: "VelocidiSDK"
+          xcode_package: "^VelocidiSDK$"
 
   build-example-applications:
     name: "Build example applications"


### PR DESCRIPTION
This is an attempt to remove coverage from the tests package. 

Using the "ignore" key in the config yml does not seem to be working. Forcing a more specific package seems to work better, although the file SanityTests.m still shows up. I was not able to understand why, nor why the coverage for the tests was not being ignored in the first place using the `ignore: "VelocidiSDK/VelocidiSDKTests/**/*"`.