### PR TITLE
Minor example changes

### DIFF
--- a/Examples/ObjcExample/ObjcExample/Info.plist
+++ b/Examples/ObjcExample/ObjcExample/Info.plist
@@ -2,21 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -35,6 +20,23 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>App would like to access IDFA for tracking purpose</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -56,7 +58,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>App would like to access IDFA for tracking purpose</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Examples/ObjcExample/ObjcExample/ViewController.m
+++ b/Examples/ObjcExample/ObjcExample/ViewController.m
@@ -17,13 +17,15 @@
     if (@available(iOS 14, *)) {
         [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
             self.trackingIsAllowed = status == ATTrackingManagerAuthorizationStatusAuthorized;
+            if (self.trackingIsAllowed) {
+                self.idfa = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+            }
         }];
     } else {
         self.trackingIsAllowed = [[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled];
-    }
-    
-    if (self.trackingIsAllowed) {
-        self.idfa = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+        if (self.trackingIsAllowed) {
+            self.idfa = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+        }
     }
 }
 

--- a/Examples/SwiftExample/SwiftExample/Info.plist
+++ b/Examples/SwiftExample/SwiftExample/Info.plist
@@ -2,21 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -35,6 +20,23 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>App would like to access IDFA for tracking purpose</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -56,7 +58,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>App would like to access IDFA for tracking purpose</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Examples/SwiftExample/SwiftExample/ViewController.swift
+++ b/Examples/SwiftExample/SwiftExample/ViewController.swift
@@ -16,13 +16,15 @@ class ViewController: UIViewController {
         if #available(iOS 14, *) {
             ATTrackingManager.requestTrackingAuthorization { status in
                 self.trackingIsAllowed = status == .authorized
+                if self.trackingIsAllowed {
+                    self.idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
+                }
             }
         } else {
             self.trackingIsAllowed = ASIdentifierManager.shared().isAdvertisingTrackingEnabled
-        }
-
-        if trackingIsAllowed {
-            self.idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
+            if self.trackingIsAllowed {
+                self.idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
+            }
         }
     }
 
@@ -48,7 +50,7 @@ class ViewController: UIViewController {
             trackingNumber += 1
             let currentTrNumber = trackingNumber
 
-            let userId = VSDKUserId(id: self.idfa, type: "idfab")
+            let userId = VSDKUserId(id: self.idfa, type: "idfa")
             VSDKVelocidi.sharedInstance().track(trackingEvent, user: userId, onSuccess: { (_: URLResponse, _: Any) in
                 self.mainLabel.text = "Tracking request #\(currentTrNumber) successful!"
             }, onFailure: {(error: Error) in


### PR DESCRIPTION
Some minor corrections to the example applications.

- force light theme on examples so that the labels are always shown, even when the device is using a dark theme.
- make sure that the idfa variable used is set inside the callback of the user consent to avoid race conditions.