### PR TITLE
Update how IDFA is accessed in Examples

### DIFF
--- a/Examples/SwiftExample/SwiftExample/ViewController.swift
+++ b/Examples/SwiftExample/SwiftExample/ViewController.swift
@@ -12,19 +12,26 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
+    }
 
+    func useIDFA(completionHandler: @escaping (Bool, String) -> Void) {
         if #available(iOS 14, *) {
             ATTrackingManager.requestTrackingAuthorization { status in
-                self.trackingIsAllowed = status == .authorized
-                if self.trackingIsAllowed {
-                    self.idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
+                let isTrackingEnabled = status == .authorized
+                var idfa: String = ""
+                if isTrackingEnabled {
+                    idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
                 }
+                completionHandler(isTrackingEnabled, idfa)
             }
         } else {
-            self.trackingIsAllowed = ASIdentifierManager.shared().isAdvertisingTrackingEnabled
-            if self.trackingIsAllowed {
-                self.idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
+            let isTrackingEnabled = ASIdentifierManager.shared().isAdvertisingTrackingEnabled
+            var idfa: String = ""
+
+            if trackingIsAllowed {
+                idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
             }
+            completionHandler(isTrackingEnabled, idfa)
         }
     }
 
@@ -34,88 +41,100 @@ class ViewController: UIViewController {
     // MARK: Actions
     @IBAction func sendTrackingEvent(_ sender: UIButton) {
 
-        if self.trackingIsAllowed {
-            var trackingEvent = [String: Any]()
-            trackingEvent["type"] = "appView"
-            trackingEvent["siteId"] = "foo"
-            trackingEvent["clientId"] = "bar"
+        useIDFA(completionHandler: { (isTrackingEnabled, idfa) in
+            if isTrackingEnabled {
+                var trackingEvent = [String: Any]()
+                trackingEvent["type"] = "appView"
+                trackingEvent["siteId"] = "foo"
+                trackingEvent["clientId"] = "bar"
 
-            var customFields = [String: Any]()
-            customFields["debug"] = "true"
-            customFields["role"] = "superuser"
+                var customFields = [String: Any]()
+                customFields["debug"] = "true"
+                customFields["role"] = "superuser"
 
-            trackingEvent["customFields"] = customFields
-            trackingEvent["title"] = "Welcome Screen"
+                trackingEvent["customFields"] = customFields
+                trackingEvent["title"] = "Welcome Screen"
 
-            trackingNumber += 1
-            let currentTrNumber = trackingNumber
+                self.trackingNumber += 1
+                let currentTrNumber = self.trackingNumber
 
-            let userId = VSDKUserId(id: self.idfa, type: "idfa")
-            VSDKVelocidi.sharedInstance().track(trackingEvent, user: userId, onSuccess: { (_: URLResponse, _: Any) in
-                self.mainLabel.text = "Tracking request #\(currentTrNumber) successful!"
-            }, onFailure: {(error: Error) in
-                self.mainLabel.text =
-                    "Error with tracking request #\(currentTrNumber).\n Error: \(error.localizedDescription)"
-            })
-        } else {
-            self.mainLabel.text = "Could not retrieve IDFA identifier to send as User ID!"
-        }
+                let userId = VSDKUserId(id: idfa, type: "idfa")
+                VSDKVelocidi.sharedInstance()
+                    .track(trackingEvent,
+                            user: userId,
+                            onSuccess: { (_: URLResponse, _: Any) in
+                                self.mainLabel.text =
+                                    "Tracking request #\(currentTrNumber) successful!"
+                            },
+                            onFailure: {(error: Error) in
+                                self.mainLabel.text =
+                                    "Error with tracking request #\(currentTrNumber)." +
+                                    "\n Error: \(error.localizedDescription)"
+                            })
+            } else {
+                self.mainLabel.text = "Could not retrieve IDFA identifier to send as User ID!"
+            }
+        })
     }
 
     var customTrackingNumber = 0
 
     @IBAction func sendCustomTrackingEvent(_ sender: Any) {
-        if self.trackingIsAllowed {
-            let trackingEvent =
-            """
-            {
-              "clientId": "bar",
-              "siteId": "foo",
-              "type": "custom",
-              "customFields": {
-                "key": "value"
-              },
-              "customType": "custom-type"
+        useIDFA(completionHandler: { (isTrackingEnabled, idfa) in
+            if isTrackingEnabled {
+                let trackingEvent =
+                """
+                {
+                  "clientId": "bar",
+                  "siteId": "foo",
+                  "type": "custom",
+                  "customFields": {
+                    "key": "value"
+                  },
+                  "customType": "custom-type"
+                }
+                """
+
+                self.customTrackingNumber += 1
+                let currentCustomTrNumber = self.customTrackingNumber
+
+                let userId = VSDKUserId(id: idfa, type: "idfa")
+                VSDKVelocidi
+                    .sharedInstance()
+                    .track(trackingEvent, userId: userId, onSuccess: { (_: URLResponse, _: Any) in
+                    self.mainLabel.text = "Custom Tracking request #\(currentCustomTrNumber) successful!"
+                }, onFailure: {(error: Error) in
+                    self.mainLabel.text =
+                        "Error with custom tracking request #\(currentCustomTrNumber).\n" +
+                        "Error: \(error.localizedDescription)"
+                })
+            } else {
+                self.mainLabel.text = "Could not retrieve IDFA identifier to send as User ID!"
             }
-            """
-
-            customTrackingNumber += 1
-            let currentCustomTrNumber = customTrackingNumber
-
-            let userId = VSDKUserId(id: self.idfa, type: "idfa")
-            VSDKVelocidi
-                .sharedInstance()
-                .track(trackingEvent, userId: userId, onSuccess: { (_: URLResponse, _: Any) in
-                self.mainLabel.text = "Custom Tracking request #\(currentCustomTrNumber) successful!"
-            }, onFailure: {(error: Error) in
-                self.mainLabel.text =
-                    "Error with custom tracking request #\(currentCustomTrNumber).\n" +
-                    "Error: \(error.localizedDescription)"
-            })
-        } else {
-            self.mainLabel.text = "Could not retrieve IDFA identifier to send as User ID!"
-        }
+        })
     }
 
     @IBAction func sendMatchEvent(_ sender: Any) {
-        if self.trackingIsAllowed {
-            let userId1 = VSDKUserId(id: self.idfa, type: "idfa")
-            let userId2 = VSDKUserId(id: "baz", type: "fooType")
-            let idsArray = NSMutableArray(array: [userId1, userId2])
+        useIDFA(completionHandler: { (isTrackingEnabled, idfa) in
+            if isTrackingEnabled {
+                let userId1 = VSDKUserId(id: idfa, type: "idfa")
+                let userId2 = VSDKUserId(id: "baz", type: "fooType")
+                let idsArray = NSMutableArray(array: [userId1, userId2])
 
-            matchNumber += 1
-            let currentMatchNumber = matchNumber
+                self.matchNumber += 1
+                let currentMatchNumber = self.matchNumber
 
-            VSDKVelocidi
-                .sharedInstance()
-                .match("1234-providerId-56789", userIds: idsArray, onSuccess: { (_: URLResponse, _: Any) in
-                self.mainLabel.text = "Match request #\(currentMatchNumber) successful!"
-            }, onFailure: {(error: Error) in
-                self.mainLabel.text =
-                    "Error with match request #\(currentMatchNumber).\nError: \(error.localizedDescription)"
-            })
-        } else {
-            self.mainLabel.text = "Could not retrieve IDFA identifier to send as User ID!"
-        }
+                VSDKVelocidi
+                    .sharedInstance()
+                    .match("1234-providerId-56789", userIds: idsArray, onSuccess: { (_: URLResponse, _: Any) in
+                    self.mainLabel.text = "Match request #\(currentMatchNumber) successful!"
+                }, onFailure: {(error: Error) in
+                    self.mainLabel.text =
+                        "Error with match request #\(currentMatchNumber).\nError: \(error.localizedDescription)"
+                })
+            } else {
+                self.mainLabel.text = "Could not retrieve IDFA identifier to send as User ID!"
+            }
+        })
     }
 }


### PR DESCRIPTION
This PR changes how the IDFA is accessed in the Example projects. Instead of requesting it once and storing it, we always request it before using it. The seems to be more in line with how it is intended to be used and avoids situations where the privacy settings changed but we keep using the the IDFA.