### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,6 @@ jobs:
       matrix:
         include:
          - os: "macos-10.15"
-           xcode: "10.3"
-           sdk: "12.4"
-           device: "iPhone X"
-         - os: "macos-10.15"
            xcode: "11.7.0"
            sdk: "13.7"
            device: "iPhone 11"

--- a/Examples/ObjcExample/ObjcExample.xcodeproj/project.pbxproj
+++ b/Examples/ObjcExample/ObjcExample.xcodeproj/project.pbxproj
@@ -108,7 +108,7 @@
 				30BCF73622709C1E00E462A8 /* Frameworks */,
 				30BCF73722709C1E00E462A8 /* Resources */,
 				4E82CBF95466188B0C93253D /* [CP] Embed Pods Frameworks */,
-				30F36CAC261627560025FCBF /* Run Script */,
+				30F36CAC261627560025FCBF /* Run clang-format */,
 			);
 			buildRules = (
 			);
@@ -165,7 +165,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		30F36CAC261627560025FCBF /* Run Script */ = {
+		30F36CAC261627560025FCBF /* Run clang-format */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -174,14 +174,14 @@
 			);
 			inputPaths = (
 			);
-			name = "Run Script";
+			name = "Run clang-format";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "source ~/.bash_profile\ncd ${SRCROOT}\ncd ../..\nmake install-examples\n\nclang-format -style=file -i Examples/ObjcExample/**/*.m Examples/ObjcExample/**/*.h\n";
+			shellScript = "source ~/.bash_profile\ncd ${SRCROOT}\ncd ../..\nclang-format -style=file -i Examples/ObjcExample/**/*.m Examples/ObjcExample/**/*.h\n";
 		};
 		4E82CBF95466188B0C93253D /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Examples/ObjcExample/ObjcExample.xcodeproj/project.pbxproj
+++ b/Examples/ObjcExample/ObjcExample.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "source ~/.bash_profile\ncd ${SRCROOT}\ncd ..\nclang-format -style=file -i ObjcExample/**/*.m ObjcExample/**/*.h\n";
+			shellScript = "source ~/.bash_profile\ncd ${SRCROOT}\ncd ../..\nmake install-examples\n\nclang-format -style=file -i Examples/ObjcExample/**/*.m Examples/ObjcExample/**/*.h\n";
 		};
 		4E82CBF95466188B0C93253D /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
@@ -101,7 +101,7 @@
 				30B0DE2C226E022F00A0919B /* Frameworks */,
 				30B0DE2D226E022F00A0919B /* Resources */,
 				9D5B93C6D2E989AE2C83E635 /* [CP] Embed Pods Frameworks */,
-				A16A45AE25FD866900B6A451 /* ShellScript */,
+				A16A45AE25FD866900B6A451 /* Run swiftlint */,
 			);
 			buildRules = (
 			);
@@ -200,7 +200,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftExample/Pods-SwiftExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A16A45AE25FD866900B6A451 /* ShellScript */ = {
+		A16A45AE25FD866900B6A451 /* Run swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -209,13 +209,14 @@
 			);
 			inputPaths = (
 			);
+			name = "Run swiftlint";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\nsource ~/.bash_profile\ncd ${SRCROOT}\ncd ../..\nmake install-examples\n\n\"${PODS_ROOT}/SwiftLint/swiftlint\" autocorrect && \"${PODS_ROOT}/SwiftLint/swiftlint\" --strict\n";
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" autocorrect && \"${PODS_ROOT}/SwiftLint/swiftlint\" --strict\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" autocorrect && \"${PODS_ROOT}/SwiftLint/swiftlint\" --strict\n";
+			shellScript = "\nsource ~/.bash_profile\ncd ${SRCROOT}\ncd ../..\nmake install-examples\n\n\"${PODS_ROOT}/SwiftLint/swiftlint\" autocorrect && \"${PODS_ROOT}/SwiftLint/swiftlint\" --strict\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test: build
 
 examples: install-examples build-objc-example build-swift-example
 
-install-examples: build
+install-examples: install build
 	pod install --project-directory=Examples/
 
 build-objc-example: install-examples

--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,12 @@ prerequisites:
 
 oclint-examples:
 	set -o pipefail && \
-	xcodebuild -scheme VelocidiSDK -sdk iphonesimulator -workspace VelocidiSDK.xcworkspace COMPILER_INDEX_STORE_ENABLE=NO clean build && \
-	xcodebuild -scheme ObjcExample -sdk iphonesimulator -workspace VelocidiSDK.xcworkspace COMPILER_INDEX_STORE_ENABLE=NO clean build | xcpretty -r json-compilation-database --output compile_commands.json && \
+	xcodebuild -scheme ObjcExample $(XCARGS) COMPILER_INDEX_STORE_ENABLE=NO clean build | xcpretty -r json-compilation-database --output compile_commands.json && \
 	oclint-json-compilation-database -exclude Pods -exclude build -- -report-type xcode
 
 oclint:
 	set -o pipefail && \
-	xcodebuild -scheme VelocidiSDK -sdk iphonesimulator -workspace VelocidiSDK.xcworkspace COMPILER_INDEX_STORE_ENABLE=NO clean build | xcpretty -r json-compilation-database --output compile_commands.json && \
+	xcodebuild -scheme VelocidiSDK $(XCARGS) COMPILER_INDEX_STORE_ENABLE=NO clean build | xcpretty -r json-compilation-database --output compile_commands.json && \
 	oclint-json-compilation-database -exclude Pods -exclude build -- -report-type xcode
 
 swiftlint:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install:
 prerequisites:
 	.scripts/prerequisites.sh
 
-oclint-examples:
+oclint-examples: install-examples
 	set -o pipefail && \
 	xcodebuild -scheme ObjcExample $(XCARGS) COMPILER_INDEX_STORE_ENABLE=NO clean build | xcpretty -r json-compilation-database --output compile_commands.json && \
 	oclint-json-compilation-database -exclude Pods -exclude build -- -report-type xcode


### PR DESCRIPTION
* Removes tests for xcode 10.3/sdk 12.4. Running `pod install` resulted in: 
```
Couldn't determine repo type for URL: `https://cdn.cocoapods.org/`: Compilation error generating constants :
	ld: unsupported tapi file type '!tapi-tbd' in YAML file 
```
Not really sure why this started failing without us introducing any change, but it only seems to be failing in that version.
* All `make` commands use the same `sdk` and `destination`. This avoids a mismatch with including dependencies that were built for a different target and will fix the Oclint step not working.