### PR TITLE
Update GitHub actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       matrix:
         include:
-         - os: "macos-10.15"
+         - os: "macos-latest"
            xcode: "11.7.0"
            sdk: "13.7"
            device: "iPhone 11"
-         - os: "macos-10.15"
+         - os: "macos-latest"
            xcode: "12.4"
            sdk: "14.4"
            device: "iPhone 11 Pro Max"
@@ -42,7 +42,7 @@ jobs:
   build-example-applications:
     name: "Build example applications"
     needs: test
-    runs-on: "macos-10.15"
+    runs-on: "macos-latest"
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
@@ -62,7 +62,7 @@ jobs:
   run-oclint:
     name: "OClint"
     needs: test
-    runs-on: "macos-10.15"
+    runs-on: "macos-latest"
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
            device: "iPhone 11 Pro Max"
     runs-on: "${{ matrix.os }}"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "${{ matrix.xcode }}"
@@ -44,7 +44,7 @@ jobs:
     needs: test
     runs-on: "macos-10.15"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "latest-stable"
@@ -64,7 +64,7 @@ jobs:
     needs: test
     runs-on: "macos-10.15"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "latest-stable"
@@ -88,7 +88,7 @@ jobs:
     needs: test
     runs-on: "macos-latest"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "latest-stable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       matrix:
         include:
-         - xcode: "14.3.1"
+         - xcode: "11.7.0"
            sdk: "13.7"
            device: "iPhone 11"
-         - xcode: "14.3.1"
+         - xcode: "12.4"
            sdk: "14.4"
            device: "iPhone 11 Pro Max"
     runs-on: "macos-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         include:
          - xcode: "14.3.1"
-           sdk: "16.4"
+           sdk: "13.7"
            device: "iPhone 11"
          - xcode: "14.3.1"
-           sdk: "16.4"
+           sdk: "14.4"
            device: "iPhone 11 Pro Max"
     runs-on: "macos-latest"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,22 +4,20 @@ on: [push]
 
 jobs:
   test:
-    name: "Build and test Velocidi SDK using [${{ matrix.os }}, xcode${{ matrix.xcode }}, sdk${{ matrix.sdk }}, ${{ matrix.device }}]"
+    name: "Build and test Velocidi SDK using [xcode${{ matrix.xcode }}, sdk${{ matrix.sdk }}, ${{ matrix.device }}]"
     env:
       WORKSPACE: "VelocidiSDK.xcworkspace"
       SCHEME: "VelocidiSDK"
     strategy:
       matrix:
         include:
-         - os: "macos-latest"
-           xcode: "11.7.0"
+         - xcode: "11.7.0"
            sdk: "13.7"
            device: "iPhone 11"
-         - os: "macos-latest"
-           xcode: "12.4"
+         - xcode: "12.4"
            sdk: "14.4"
            device: "iPhone 11 Pro Max"
-    runs-on: "${{ matrix.os }}"
+    runs-on: "macos-latest"
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,22 @@ on: [push]
 
 jobs:
   test:
-    name: "Build and test Velocidi SDK using [xcode${{ matrix.xcode }}, sdk${{ matrix.sdk }}, ${{ matrix.device }}]"
+    name: "Build and test Velocidi SDK using [${{ matrix.os }}, xcode${{ matrix.xcode }}, sdk${{ matrix.sdk }}, ${{ matrix.device }}]"
     env:
       WORKSPACE: "VelocidiSDK.xcworkspace"
       SCHEME: "VelocidiSDK"
     strategy:
       matrix:
         include:
-         - xcode: "11.7.0"
+         - os: "macos-latest"
+           xcode: "11.7.0"
            sdk: "13.7"
            device: "iPhone 11"
-         - xcode: "12.4"
+         - os: "macos-latest"
+           xcode: "12.4"
            sdk: "14.4"
            device: "iPhone 11 Pro Max"
-    runs-on: "macos-latest"
+    runs-on: "${{ matrix.os }}"
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         include:
          - xcode: "14.3.1"
-           sdk: "13.7"
+           sdk: "16.4"
            device: "iPhone 11"
          - xcode: "14.3.1"
-           sdk: "14.4"
+           sdk: "16.4"
            device: "iPhone 11 Pro Max"
     runs-on: "macos-latest"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       matrix:
         include:
-         - xcode: "11.7.0"
+         - xcode: "14.3.1"
            sdk: "13.7"
            device: "iPhone 11"
-         - xcode: "12.4"
+         - xcode: "14.3.1"
            sdk: "14.4"
            device: "iPhone 11 Pro Max"
     runs-on: "macos-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       matrix:
         include:
-         - os: "macos-latest"
+         - os: "macos-10.15"
            xcode: "11.7.0"
            sdk: "13.7"
            device: "iPhone 11"
-         - os: "macos-latest"
+         - os: "macos-10.15"
            xcode: "12.4"
            sdk: "14.4"
            device: "iPhone 11 Pro Max"
@@ -42,7 +42,7 @@ jobs:
   build-example-applications:
     name: "Build example applications"
     needs: test
-    runs-on: "macos-latest"
+    runs-on: "macos-10.15"
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
@@ -62,7 +62,7 @@ jobs:
   run-oclint:
     name: "OClint"
     needs: test
-    runs-on: "macos-latest"
+    runs-on: "macos-10.15"
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
Updating GitHub actions to the latest released stable version.

This PR was programmatically created by the `github-actions-version-updater` script.

Note that further manual action may be required if the action version updating introduces breaking changes.

### Testing

Relying on CI. Please validate the changes for all of the updated GitHub Actions workflows.
